### PR TITLE
make 'hide from other' enabled by default

### DIFF
--- a/app/src/main/java/net/nullsum/audinaut/fragments/SettingsFragment.java
+++ b/app/src/main/java/net/nullsum/audinaut/fragments/SettingsFragment.java
@@ -149,7 +149,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 		update();
 
 		if (Constants.PREFERENCES_KEY_HIDE_MEDIA.equals(key)) {
-			setHideMedia(sharedPreferences.getBoolean(key, false));
+			setHideMedia(sharedPreferences.getBoolean(key, true));
 		}
 		else if (Constants.PREFERENCES_KEY_MEDIA_BUTTONS.equals(key)) {
 			setMediaButtonsEnabled(sharedPreferences.getBoolean(key, true));

--- a/app/src/main/res/xml/settings_cache.xml
+++ b/app/src/main/res/xml/settings_cache.xml
@@ -74,7 +74,7 @@
 			android:title="@string/settings.hide_media_title"
 			android:summary="@string/settings.hide_media_summary"
 			android:key="hideMedia"
-			android:defaultValue="false"/>
+			android:defaultValue="true"/>
 
 		<CheckBoxPreference
 			android:title="@string/settings.screen_lit_title"


### PR DESCRIPTION
This implements #1, enabling "hide from other" by default (for new installations)