### PR TITLE
Fix slash escape in REST API path

### DIFF
--- a/app/src/main/java/net/nullsum/audinaut/util/Util.java
+++ b/app/src/main/java/net/nullsum/audinaut/util/Util.java
@@ -350,7 +350,8 @@ public final class Util {
         String username = prefs.getString(Constants.PREFERENCES_KEY_USERNAME + instance, null);
         String password = prefs.getString(Constants.PREFERENCES_KEY_PASSWORD + instance, null);
 
-        builder.addPathSegment("rest/" + method + ".view");
+        builder.addPathSegment("rest");
+        builder.addPathSegment(method + ".view");
 
         int hash = (username + password).hashCode();
         Pair<String, String> values = tokens.get(hash);


### PR DESCRIPTION
addPathSegment escapes slash. This PR changes endpoint from
rest%2Ffoo.view to rest/foo.view