### PR TITLE
Ensure that widget controls change color properly when dark mode is enabled

### DIFF
--- a/app/src/main/res/drawable-night/notification_close.xml
+++ b/app/src/main/res/drawable-night/notification_close.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable-night/notification_media_backward.xml
+++ b/app/src/main/res/drawable-night/notification_media_backward.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z"/>
+</vector>

--- a/app/src/main/res/drawable-night/notification_media_fastforward.xml
+++ b/app/src/main/res/drawable-night/notification_media_fastforward.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M4,18l8.5,-6L4,6v12zM13,6v12l8.5,-6L13,6z"/>
+</vector>

--- a/app/src/main/res/drawable-night/notification_media_forward.xml
+++ b/app/src/main/res/drawable-night/notification_media_forward.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
+</vector>

--- a/app/src/main/res/drawable-night/notification_media_pause.xml
+++ b/app/src/main/res/drawable-night/notification_media_pause.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
+</vector>

--- a/app/src/main/res/drawable-night/notification_media_rewind.xml
+++ b/app/src/main/res/drawable-night/notification_media_rewind.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M11,18L11,6l-8.5,6 8.5,6zM11.5,12l8.5,6L20,6l-8.5,6z"/>
+</vector>

--- a/app/src/main/res/drawable-night/notification_media_start.xml
+++ b/app/src/main/res/drawable-night/notification_media_start.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/darkElement" android:pathData="M8,5v14l11,-7z"/>
+</vector>


### PR DESCRIPTION
This is not an ideal solution (not "true" dark mode support) but it works for now, and because you are using vector images the cost is small despite duplicating the images. Only tested on my Pixel 2 XL on Android 10. Solves #42. Apologies for messy commit messages, not used to using git in public.