### PR TITLE
Add 24Kbps (equivalent to Spotify low) and 48Kbps options

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -37,7 +37,9 @@
     </string-array>
 
     <string-array name="maxBitrateValues">
+        <item>24</item>
         <item>32</item>
+        <item>48</item>
         <item>64</item>
         <item>80</item>
         <item>96</item>
@@ -51,7 +53,9 @@
     </string-array>
 
     <string-array name="maxBitrateNames">
+        <item>@string/settings.max_bitrate_24</item>
         <item>@string/settings.max_bitrate_32</item>
+        <item>@string/settings.max_bitrate_48</item>
         <item>@string/settings.max_bitrate_64</item>
         <item>@string/settings.max_bitrate_80</item>
         <item>@string/settings.max_bitrate_96</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,9 @@
     <string name="settings.network_title">Network</string>
     <string name="settings.max_bitrate_wifi">Max Audio bitrate - Wi-Fi</string>
     <string name="settings.max_bitrate_mobile">Max Audio bitrate - Mobile</string>
+    <string name="settings.max_bitrate_24">24 Kbps</string>
     <string name="settings.max_bitrate_32">32 Kbps</string>
+    <string name="settings.max_bitrate_48">48 Kbps</string>
     <string name="settings.max_bitrate_64">64 Kbps</string>
     <string name="settings.max_bitrate_80">80 Kbps</string>
     <string name="settings.max_bitrate_96">96 Kbps</string>


### PR DESCRIPTION
Solves #28. As for 24Kbps, it is a real use case, Spotify uses this bitrate with HE-AACv2 (available from libfdk through ffmpeg on fedora) for its "Low" quality option. In places where mobile data is expensive this kind of option can be very useful.