### PR TITLE
Sort artists using case insensitive comparison when offline

### DIFF
--- a/app/src/main/java/net/nullsum/audinaut/fragments/SelectArtistFragment.java
+++ b/app/src/main/java/net/nullsum/audinaut/fragments/SelectArtistFragment.java
@@ -169,7 +169,7 @@ public class SelectArtistFragment extends SelectRecyclerFragment<Serializable> i
             String musicFolderId = Util.getSelectedMusicFolderId(context);
 
             Indexes indexes = musicService.getIndexes(musicFolderId, refresh, context, listener);
-            indexes.sortChildren(context);
+            indexes.sortChildren();
             items = new ArrayList<>(indexes.getShortcuts().size() + indexes.getArtists().size());
             items.addAll(indexes.getShortcuts());
             items.addAll(indexes.getArtists());
@@ -184,8 +184,7 @@ public class SelectArtistFragment extends SelectRecyclerFragment<Serializable> i
             }
 
             Indexes indexes = new Indexes();
-            //indexes.setArtists = artists;
-            indexes.sortChildren(context);
+            indexes.sortChildren();
             items = new ArrayList<>(indexes.getArtists());
 
             entries = dir.getChildren(false, true);

--- a/app/src/main/java/net/nullsum/audinaut/service/OfflineMusicService.java
+++ b/app/src/main/java/net/nullsum/audinaut/service/OfflineMusicService.java
@@ -71,6 +71,7 @@ public class OfflineMusicService implements MusicService {
     public Indexes getIndexes(String musicFolderId, boolean refresh, Context context, ProgressListener progressListener) {
         List<Artist> artists = new ArrayList<>();
         List<Entry> entries = new ArrayList<>();
+
         File root = FileUtil.getMusicDirectory(context);
         for (File file : FileUtil.listFiles(root)) {
             if (file.isDirectory()) {

--- a/app/src/main/kotlin/net/nullsum/audinaut/domain/Indexes.kt
+++ b/app/src/main/kotlin/net/nullsum/audinaut/domain/Indexes.kt
@@ -1,11 +1,15 @@
 package net.nullsum.audinaut.domain
 
-import android.content.Context
 import java.io.Serializable
+import java.util.*
 
 class Indexes(var shortcuts: MutableList<Artist> = mutableListOf(),
               var artists: MutableList<Artist> = mutableListOf(),
               var entries: MutableList<MusicDirectory.Entry> = mutableListOf()) : Serializable {
-    fun sortChildren(context: Context) {
+
+    fun sortChildren() {
+        shortcuts.sortBy { s -> s.id.toLowerCase(Locale.ROOT)  }
+        artists.sortBy { a -> a.name.toLowerCase(Locale.ROOT) }
+        entries.sortBy { e -> e.artist.toLowerCase(Locale.ROOT) }
     }
 }


### PR DESCRIPTION
When online, Audinaut uses the artists in the order the server returns them. When offline, this order depends on the order in which `FileUtils` returns the files and directories.

This means that currently Audinaut shows artists in the following order when online (uses the sorting from the server):

```
Air
algodao
Black Keys
```

But like this when offline:

```
Air
Black Keys
algodao
```

Which I think is confusing to the user.

This PR changes Audinat to sort artists with case insensitive comparison, the same way the server returns them.

I am not sure this is the best way to implement this. Initially I just implemented `Indexes.sortChildren` which was implemented as a NOOP. This would trigger the sorting for both offline and online. This seemed like a better solution, but I was worried this would have an impact for users with very big libraries, since they the library would be sorted from the server and then Audinaut would sort it again. Maybe this was why the method was left implemented?

Please let me know if that solution would be better and I can implement it back.

Thanks