### PR TITLE
fix invisible back/forward buttons on widgets (#81)

### DIFF
--- a/app/src/main/java/net/nullsum/audinaut/provider/AudinautWidgetProvider.java
+++ b/app/src/main/java/net/nullsum/audinaut/provider/AudinautWidgetProvider.java
@@ -245,6 +245,10 @@ public class AudinautWidgetProvider extends AppWidgetProvider {
             views.setImageViewResource(R.id.control_play, R.drawable.widget_media_start);
         }
 
+        // Set next/back button images
+        views.setImageViewResource(R.id.control_next, R.drawable.widget_media_forward);
+        views.setImageViewResource(R.id.control_previous, R.drawable.widget_media_backward);
+
         // Set the cover art
         try {
             boolean large = false;


### PR DESCRIPTION
Solves #81. The buttons were drawing before, but not the icons. Considering the XML definitions were basically the same I looked for other differences between play/pause and these buttons. The play/pause had its image set in the widget provider part of the program, while back/forward did not. Adding similar statements to set the icons for these buttons seems to fix the issue.

Tested in Nexus 4 Lollipop emulator:
![Screenshot_1594319361](https://user-images.githubusercontent.com/27998345/87077885-caaf8100-c1f1-11ea-9a88-501a9bb30498.png)

Also tested physically on Android 11 on a Pixel 2 XL.
