### PR TITLE
change day/night themes to support dark mode setting on Android 10+

### DIFF
--- a/app/src/main/java/net/nullsum/audinaut/activity/SubsonicActivity.java
+++ b/app/src/main/java/net/nullsum/audinaut/activity/SubsonicActivity.java
@@ -24,6 +24,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -85,7 +86,13 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
     private static ImageLoader IMAGE_LOADER;
 
     static {
-        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+        // If Android Pie or older, set night mode by system clock
+        if (Build.VERSION.SDK_INT<29) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+        } else {
+            // Else, for Android 10+, follow system dark mode setting
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+        }
     }
 
     final List<SubsonicFragment> backStack = new ArrayList<>();

--- a/app/src/main/java/net/nullsum/audinaut/util/ThemeUtil.java
+++ b/app/src/main/java/net/nullsum/audinaut/util/ThemeUtil.java
@@ -18,7 +18,10 @@ package net.nullsum.audinaut.util;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.util.Log;
+
+import androidx.appcompat.app.AppCompatDelegate;
 
 import net.nullsum.audinaut.R;
 import net.nullsum.audinaut.activity.SettingsActivity;
@@ -33,7 +36,15 @@ public final class ThemeUtil {
 
     public static String getTheme(Context context) {
         SharedPreferences prefs = Util.getPreferences(context);
-        String theme = prefs.getString(Constants.PREFERENCES_KEY_THEME, null);
+        String theme;
+
+        if (Build.VERSION.SDK_INT<29) {
+            // If Android Pie or older, default to null (handled below as light)
+            theme = prefs.getString(Constants.PREFERENCES_KEY_THEME, null);
+        } else {
+            // Else, for Android 10+, default to follow system dark mode setting
+            theme = prefs.getString(Constants.PREFERENCES_KEY_THEME, THEME_DAY_NIGHT);
+        }
 
         if (THEME_DAY_NIGHT.equals(theme)) {
             int currentNightMode = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;

--- a/app/src/main/java/net/nullsum/audinaut/util/ThemeUtil.java
+++ b/app/src/main/java/net/nullsum/audinaut/util/ThemeUtil.java
@@ -21,8 +21,6 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.appcompat.app.AppCompatDelegate;
-
 import net.nullsum.audinaut.R;
 import net.nullsum.audinaut.activity.SettingsActivity;
 import net.nullsum.audinaut.activity.SubsonicFragmentActivity;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,8 +162,8 @@
     <string name="settings.theme_light">Light</string>
     <string name="settings.theme_dark">Dark</string>
     <string name="settings.theme_black">Black</string>
-    <string name="settings.theme_day_night">Day/Night</string>
-    <string name="settings.theme_day_black_night">Day/Black Night</string>
+    <string name="settings.theme_day_night">Dynamic (Light/Dark)</string>
+    <string name="settings.theme_day_black_night">Dynamic (Light/Black)</string>
     <string name="settings.theme_fullscreen">Fullscreen</string>
     <string name="settings.theme_fullscreen_summary">Hide as many UI elements as Android will allow</string>
     <string name="settings.track_title">Display Track #</string>

--- a/app/src/main/res/xml/settings_appearance.xml
+++ b/app/src/main/res/xml/settings_appearance.xml
@@ -3,7 +3,6 @@
     android:title="@string/settings.appearance_title">
 
     <ListPreference
-        android:defaultValue="light"
         android:entries="@array/themeNames"
         android:entryValues="@array/themeValues"
         android:key="theme"


### PR DESCRIPTION
On Android 10+ devices there is a system-wide dark mode that users are beginning to expect will extend to their apps as well. The current day/night theme in Audinaut sets itself using the system clock. This pull request renames the day/night theme to "Dynamic" and changes its functionality on Android 10 and up to instead follow the system dark mode theme. On Android 9 and below, the old functionality should be preserved. In addition, while the app formerly always initially defaulted to the light theme, it will now default to matching the system theme on Android 10+.

Demo:
![test](https://user-images.githubusercontent.com/27998345/87091109-220c1c00-c207-11ea-9ef6-b67ff8a223a9.gif)

