### PR TITLE
Theme tweaks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.media:media:1.1.0"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }
 
 buildscript {

--- a/app/src/main/res/drawable/black_gradient.xml
+++ b/app/src/main/res/drawable/black_gradient.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:angle="270"
+                android:startColor="#ff000000"
+                android:centerColor="#00000000"
+                android:endColor="#ff000000"
+                android:type="linear"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/download.xml
+++ b/app/src/main/res/layout/download.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <FrameLayout
         android:id="@+id/download_album_art_background"
@@ -38,18 +39,38 @@
                 android:background="@android:color/transparent"
                 android:orientation="vertical">
 
-                <RelativeLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:layout_weight="1">
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    app:layout_constraintDimensionRatio="1">
 
-                    <net.nullsum.audinaut.view.RecyclingImageView
-                        android:id="@+id/download_album_art_image"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:scaleType="fitCenter" />
+                    <androidx.cardview.widget.CardView
+                        android:id="@+id/cardView"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_marginLeft="24dp"
+                        android:layout_marginTop="24dp"
+                        android:layout_marginRight="24dp"
+                        android:layout_marginBottom="24dp"
+                        app:cardCornerRadius="8dp"
+                        app:cardElevation="12dp"
+                        app:layout_constraintDimensionRatio="1"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintHorizontal_chainStyle="packed"
+                        app:layout_constraintVertical_chainStyle="packed">
 
-                </RelativeLayout>
+                        <net.nullsum.audinaut.view.RecyclingImageView
+                            android:id="@+id/download_album_art_image"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:scaleType="fitCenter" />
+                    </androidx.cardview.widget.CardView>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
             </LinearLayout>
 

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="LaunchScreen" parent="@style/Theme.AppCompat.Light.DarkActionBar">
+        <item name="android:windowBackground">@color/black</item>
+    </style>
+
+    <style name="Theme.Audinaut.Light" parent="@style/Theme.AppCompat.Light.DarkActionBar">
+        <item name="actionModeBackground">@color/background_material_light</item>
+        <item name="actionModeCloseButtonStyle">@style/DarkCloseButton</item>
+        <item name="actionModeStyle">@style/LightActionMode</item>
+        <item name="actionbarBackgroundColor">@android:color/transparent</item>
+        <item name="actionbarPopupStyle">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="actionbarSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle</item>
+        <item name="actionbarThemeStyle">@style/ThemeOverlay.AppCompat.ActionBar</item>
+        <item name="actionbarTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title</item>
+        <item name="gradient">@drawable/light_gradient</item>
+        <item name="actionbar_backward">@drawable/media_backward</item>
+        <item name="actionbar_element_color">@color/lightElement</item>
+        <item name="actionbar_fastforward">@drawable/media_fastforward</item>
+        <item name="actionbar_forward">@drawable/media_forward</item>
+        <item name="actionbar_pause">@drawable/media_pause</item>
+        <item name="actionbar_rewind">@drawable/media_rewind</item>
+        <item name="actionbar_start">@drawable/media_start</item>
+        <item name="actionbar_stop">@drawable/media_stop</item>
+        <item name="add">@drawable/ic_action_add</item>
+        <item name="add_person">@drawable/ic_menu_add_person</item>
+        <item name="android:spinnerItemStyle">@style/LightSpinnerItem</item>
+        <item name="cardBackgroundDrawable">@drawable/card_rounded_corners</item>
+        <item name="card_background">@android:color/white</item>
+        <item name="colorAccent">@color/lightAccent</item>
+        <item name="colorPrimary">@color/lightPrimary</item>
+        <item name="colorPrimaryDark">@color/overlayColor</item>
+        <item name="download">@drawable/ic_menu_download</item>
+        <item name="download_none">@drawable/download_none</item>
+        <item name="downloading">@drawable/downloading</item>
+        <item name="drawerArrowStyle">@style/Audinaut.DrawerArrow</item>
+        <item name="drawerDownloading">@drawable/ic_menu_download</item>
+        <item name="drawerHeaderBackground">@color/lightPrimary</item>
+        <item name="drawerLibrary">@drawable/ic_menu_library</item>
+        <item name="drawerPlaylists">@drawable/ic_menu_playlist</item>
+        <item name="drawerSettings">@drawable/ic_menu_settings</item>
+        <item name="drawerSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle.Inverse</item>
+        <item name="drawerTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title.Inverse</item>
+        <item name="element_color">@color/lightElement</item>
+        <item name="media_button_backward">@drawable/media_backward</item>
+        <item name="media_button_fastforward">@drawable/media_fastforward</item>
+        <item name="media_button_forward">@drawable/media_forward</item>
+        <item name="media_button_pause">@drawable/media_pause</item>
+        <item name="media_button_repeat_all">@drawable/media_repeat_all</item>
+        <item name="media_button_repeat_off">@drawable/media_repeat_off</item>
+        <item name="media_button_repeat_single">@drawable/media_repeat_single</item>
+        <item name="media_button_rewind">@drawable/media_rewind</item>
+        <item name="media_button_start">@drawable/media_start</item>
+        <item name="media_button_stop">@drawable/media_stop</item>
+        <item name="offline_icon">@drawable/main_offline</item>
+        <item name="playing">@drawable/playing</item>
+        <item name="refresh">@drawable/actionbar_refresh</item>
+        <item name="remove">@drawable/ic_menu_remove</item>
+        <item name="save">@drawable/actionbar_save</item>
+        <item name="search">@drawable/actionbar_search</item>
+        <item name="select_server">@drawable/main_select_server</item>
+        <item name="select_tabs">@drawable/main_select_tabs</item>
+        <item name="shuffle">@drawable/ic_menu_shuffle</item>
+        <item name="shuffle_button">@drawable/ic_menu_shuffle</item>
+        <item name="toggle_list">@drawable/action_toggle_list</item>
+        <item name="volume">@drawable/ic_action_volume</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Theme.Audinaut.Dark" parent="@style/Theme.AppCompat">
+        <item name="gradient">@drawable/dark_gradient</item>
+        <item name="actionModeBackground">@color/background_material_dark</item>
+        <item name="actionbarBackgroundColor">@android:color/transparent</item>
+        <item name="actionbarPopupStyle">@style/ThemeOverlay.AppCompat.Dark</item>
+        <item name="actionbarSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle</item>
+        <item name="actionbarThemeStyle">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <item name="actionbarTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title</item>
+        <item name="actionbar_backward">@drawable/media_backward</item>
+        <item name="actionbar_element_color">@color/darkElement</item>
+        <item name="actionbar_fastforward">@drawable/media_fastforward</item>
+        <item name="actionbar_forward">@drawable/media_forward</item>
+        <item name="actionbar_pause">@drawable/media_pause</item>
+        <item name="actionbar_rewind">@drawable/media_rewind</item>
+        <item name="actionbar_start">@drawable/media_start</item>
+        <item name="actionbar_stop">@drawable/media_stop</item>
+        <item name="add">@drawable/ic_action_add</item>
+        <item name="add_person">@drawable/ic_menu_add_person</item>
+        <item name="cardBackgroundDrawable">@drawable/card_rounded_corners</item>
+        <item name="card_background">@android:color/black</item>
+        <item name="colorAccent">@color/lightAccent</item>
+        <item name="colorPrimary">@color/lightPrimary</item>
+        <item name="colorPrimaryDark">@color/background_material_dark</item>
+        <item name="download">@drawable/ic_menu_download</item>
+        <item name="download_none">@drawable/download_none</item>
+        <item name="downloading">@drawable/downloading</item>
+        <item name="drawerArrowStyle">@style/Audinaut.DrawerArrow</item>
+        <item name="drawerDownloading">@drawable/ic_menu_download</item>
+        <item name="drawerHeaderBackground">@color/lightPrimaryDark</item>
+        <item name="drawerLibrary">@drawable/ic_menu_library</item>
+        <item name="drawerPlaylists">@drawable/ic_menu_playlist</item>
+        <item name="drawerSettings">@drawable/ic_menu_settings</item>
+        <item name="drawerSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle</item>
+        <item name="drawerTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title</item>
+        <item name="element_color">@color/darkElement</item>
+        <item name="media_button_backward">@drawable/media_backward</item>
+        <item name="media_button_fastforward">@drawable/media_fastforward</item>
+        <item name="media_button_forward">@drawable/media_forward</item>
+        <item name="media_button_pause">@drawable/media_pause</item>
+        <item name="media_button_repeat_all">@drawable/media_repeat_all</item>
+        <item name="media_button_repeat_off">@drawable/media_repeat_off</item>
+        <item name="media_button_repeat_single">@drawable/media_repeat_single</item>
+        <item name="media_button_rewind">@drawable/media_rewind</item>
+        <item name="media_button_start">@drawable/media_start</item>
+        <item name="media_button_stop">@drawable/media_stop</item>
+        <item name="offline_icon">@drawable/main_offline</item>
+        <item name="playing">@drawable/playing</item>
+        <item name="refresh">@drawable/actionbar_refresh</item>
+        <item name="remove">@drawable/ic_menu_remove</item>
+        <item name="save">@drawable/actionbar_save</item>
+        <item name="search">@drawable/actionbar_search</item>
+        <item name="select_server">@drawable/main_select_server</item>
+        <item name="select_tabs">@drawable/main_select_tabs</item>
+        <item name="shuffle">@drawable/ic_menu_shuffle</item>
+        <item name="shuffle_button">@drawable/ic_menu_shuffle</item>
+        <item name="toggle_list">@drawable/action_toggle_list</item>
+        <item name="volume">@drawable/ic_action_volume</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowActionModeOverlay">true</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Theme.Audinaut.Black" parent="Theme.Audinaut.Dark">
+        <item name="gradient">@drawable/black_gradient</item>
+        <item name="actionModeBackground">@android:color/black</item>
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="colorPrimaryDark">@android:color/black</item>
+    </style>
+
+    <style name="Audinaut.DrawerArrow" parent="Widget.AppCompat.DrawerArrowToggle">
+        <item name="spinBars">true</item>
+    </style>
+
+    <style name="LightSpinnerItem" parent="Widget.AppCompat.TextView.SpinnerItem">
+        <item name="android:textColor">?android:attr/textColorPrimary</item>
+    </style>
+
+    <style name="DarkSpinnerItem" parent="Widget.AppCompat.TextView.SpinnerItem">
+        <item name="android:textColor">?android:attr/textColorPrimaryInverse</item>
+    </style>
+
+    <style name="LightActionMode" parent="@style/Widget.AppCompat.ActionMode">
+        <item name="titleTextStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title.Inverse</item>
+        <item name="subtitleTextStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle.Inverse</item>
+    </style>
+
+    <style name="DarkCloseButton" parent="@style/Widget.AppCompat.ActionButton.CloseMode">
+        <item name="colorControlNormal">@android:color/black</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -134,6 +134,7 @@
     </style>
 
     <style name="Theme.Audinaut.Black" parent="Theme.Audinaut.Dark">
+        <item name="gradient">@drawable/black_gradient</item>
         <item name="actionModeBackground">@android:color/black</item>
         <item name="android:windowBackground">@android:color/black</item>
         <item name="colorPrimaryDark">@android:color/black</item>


### PR DESCRIPTION
- Lollipop does not support the theme variable used to make status icons dark on a light background. Status bar icons were thus invisible on lollipop. I have added a separate theme definition file for v21 and v22 that gives lollipop a grey status bar so that icons remain legible when using the light theme.
- The black theme now has its own blur gradient definition that leaves more of the screen black and fades more elegantly into the black appbar and nav buttons.
- Album art on the now playing screen now has rounded corners, a slight margin around the screen's edges, and a subtle drop shadow for a slightly more modern look.

![Screenshot_1594339882](https://user-images.githubusercontent.com/27998345/87102601-61933200-c220-11ea-9996-91e87f4552ec.png)
