### PR TITLE
Allow User Trusted Credentials

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
         android:icon="@drawable/launch"
         android:label="@string/common.appname"
         android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/LaunchScreen">
 
         <uses-library android:name="android.test.runner" />

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system"/>
+
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Subsonic/Ampache are self-hosted applications and should need to be able to support a user defined root certificate if that is installed on the android device.  The default of android applications is to ignore the user trusted credentials.  This patch overrides this by allowing certificates that are signed by certificates added by the user to their device.

See: https://developer.android.com/training/articles/security-config