### PR TITLE
Fix search for some backends

### DIFF
--- a/app/src/main/java/net/nullsum/audinaut/activity/QueryReceiverActivity.java
+++ b/app/src/main/java/net/nullsum/audinaut/activity/QueryReceiverActivity.java
@@ -65,10 +65,10 @@ public class QueryReceiverActivity extends AppCompatActivity {
             intent.putExtra(Constants.INTENT_EXTRA_VIEW_ALBUM, true);
             if (albumId.indexOf("ar-") == 0) {
                 intent.putExtra(Constants.INTENT_EXTRA_NAME_ARTIST, true);
-                albumId = albumId.replace("ar-", "");
+                albumId = albumId.replaceFirst("ar-", "");
             } else if (albumId.indexOf("so-") == 0) {
                 intent.putExtra(Constants.INTENT_EXTRA_SEARCH_SONG, name);
-                albumId = albumId.replace("so-", "");
+                albumId = albumId.replaceFirst("so-", "");
             }
             intent.putExtra(Constants.INTENT_EXTRA_NAME_ID, albumId);
             if (name != null) {


### PR DESCRIPTION
I'm using Audinaut with [Gonic](https://github.com/sentriz/gonic). Gonic returns the artist ids like `ar-000` and Audinaut is adding `ar-` at the begining of the id: https://github.com/nvllsvm/Audinaut/blob/4c5406c916974ad768f0bcbf350ef30968f0d62b/app/src/main/java/net/nullsum/audinaut/provider/AudinautSearchProvider.java#L139

so the resulting artist id is `ar-ar-000`. When a search result is clicked, Audinaut removes all the `ar-` in the string with a resulting artist id `000` and gonic complains about missing id parameter.